### PR TITLE
Fix resize listener cleanup

### DIFF
--- a/src/lib/AR.svelte
+++ b/src/lib/AR.svelte
@@ -76,6 +76,12 @@
     let canvas: HTMLCanvasElement;
     let ctx: CanvasRenderingContext2D;
 
+    const resizeHandler = () => {
+        canvas.width = window.innerWidth;
+        canvas.height = window.innerHeight;
+        updateHitboxes();
+    };
+
     // Variables pour le système de particules
     let particles: Particle[] = [];
     let particleContainer: HTMLElement | null = null;
@@ -463,12 +469,7 @@
         }
 
         // Gérer le redimensionnement de la fenêtre
-        window.addEventListener('resize', () => {
-            canvas.width = window.innerWidth;
-            canvas.height = window.innerHeight;
-            // Forcer une mise à jour des hitbox au redimensionnement
-            updateHitboxes();
-        });
+        window.addEventListener('resize', resizeHandler);
     }
 
     // Boucle d'animation pour mettre à jour en continu les hitbox
@@ -1084,7 +1085,7 @@
             scene.removeEventListener('click', handleSceneClick);
         }
 
-        window.removeEventListener('resize', () => {});
+        window.removeEventListener('resize', resizeHandler);
 
         if (canvas && canvas.parentNode) {
             canvas.parentNode.removeChild(canvas);


### PR DESCRIPTION
## Summary
- refactor the resize listener in `AR.svelte`
- use a named handler and properly remove it in `onDestroy`

## Testing
- `npm run check` *(fails: svelte-check reports TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_684045c2b9b08321b83135de36ef5f7e